### PR TITLE
Feature/improve test coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     "require": {
         "php": "^7.3|^8.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
-      "ext-http": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.3",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0",
+        "laravel/framework": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.3",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0"
+        "laravel/framework": "^6.0|^7.0|^8.0",
+      "ext-http": "*"
     },
     "require-dev": {
         "mockery/mockery": "^1.4.3",

--- a/src/ImageService.php
+++ b/src/ImageService.php
@@ -27,7 +27,7 @@ class ImageService
      */
     public function createImage(File $file)
     {
-        $image = new Image();
+        $image = $this->makeImage();
 
         $fileName = Str::slug($file->getBasename()) .'.'. $file->guessExtension();
 
@@ -123,5 +123,13 @@ class ImageService
         }
 
         return false;
+    }
+
+    /**
+     * @return \Exolnet\Image\Image
+     */
+    protected function makeImage(): Image
+    {
+        return new Image();
     }
 }

--- a/src/ImageService.php
+++ b/src/ImageService.php
@@ -66,9 +66,8 @@ class ImageService
     public function deleteImage(Image $image)
     {
         $this->destroy($image);
-        $image->delete(); // TODO-FG: Move this to an Eloquent Repository.
 
-        return false;
+        return $image->delete(); // TODO-FG: Move this to an Eloquent Repository.
     }
 
     /**

--- a/src/Repository/FilesystemRepository.php
+++ b/src/Repository/FilesystemRepository.php
@@ -1,7 +1,7 @@
 <?php namespace Exolnet\Image\Repository;
 
-use Exolnet\Core\Exceptions\ServiceValidationException;
 use Exolnet\Image\Imageable;
+use \InvalidArgumentException;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -26,12 +26,12 @@ class FilesystemRepository
      * @param \Exolnet\Image\Imageable                    $image
      * @param \Symfony\Component\HttpFoundation\File\File $file
      * @return bool
-     * @throws \Exolnet\Core\Exceptions\ServiceValidationException
+     * @throws \InvalidArgumentException
      */
-    public function store(Imageable $image, File $file)
+    public function store(Imageable $image, File $file): bool
     {
         if (! $image->getFilename()) {
-            throw new ServiceValidationException('Could not store image with an empty filename.');
+            throw new InvalidArgumentException('Could not store image with an empty filename.');
         }
 
         $path     = dirname($image->getImagePath());
@@ -42,7 +42,7 @@ class FilesystemRepository
         }
 
         if (! $this->filesystem->isWritable($path)) {
-            throw new ServiceValidationException('The image base path "'. $path .'" is not writable.');
+            throw new InvalidArgumentException('The image base path "'. $path .'" is not writable.');
         }
 
         $file->move($path, $filename);

--- a/tests/Unit/FilesystemRepositoryTest.php
+++ b/tests/Unit/FilesystemRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Exolnet\Image\Tests\Unit;
+
+use Exolnet\Image\Image;
+use Exolnet\Image\Repository\FilesystemRepository;
+use Exolnet\Image\Tests\UnitTest;
+use Illuminate\Filesystem\Filesystem;
+use Mockery as m;
+use Symfony\Component\HttpFoundation\File\File;
+
+class FilesystemRepositoryTest extends UnitTest
+{
+    protected $filesystemRepository;
+
+    protected $filesystem;
+
+    public function setUp(): void
+    {
+        $this->filesystem = new Filesystem();
+        $this->filesystemRepository = new FilesystemRepository($this->filesystem);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testItIsInitializable()
+    {
+        $this->assertInstanceOf(FilesystemRepository::class, $this->filesystemRepository);
+    }
+
+    public function testStore()
+    {
+        $file = m::mock(File::class);
+        $image = m::mock(Image::class);
+
+        $fakePath = '/src/image.png';
+        $fakeFileName = 'image.png';
+
+        $image->shouldReceive('getFileName')->once()->andReturn($fakePath);
+        $image->shouldReceive('getImagePath')->twice()->andReturn($fakeFileName);
+
+        $file->shouldReceive('move')->once()->withArgs(
+            function ($fakePath, $fakeFileName) {
+                return true;
+            }
+        )->andReturnSelf();
+
+        $this->assertTrue($this->filesystemRepository->store($image, $file));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testStoreEmptyImageFileName(): void
+    {
+        $this->expectExceptionMessage('Could not store image with an empty filename.');
+        $file = m::mock(File::class);
+        $image = m::mock(Image::class);
+
+        $emptyFileName = '';
+        $image->shouldReceive('getFileName')->once()->andReturn($emptyFileName);
+
+        $this->filesystemRepository->store($image, $file);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testDestroy(): void
+    {
+        $image = m::mock(Image::class);
+        $fakeFileName = 'image.png';
+        $image->shouldReceive('getImagePath')->once()->andReturn($fakeFileName);
+
+        $this->assertTrue($this->filesystemRepository->destroy($image));
+    }
+}

--- a/tests/Unit/ImageServiceTest.php
+++ b/tests/Unit/ImageServiceTest.php
@@ -2,32 +2,106 @@
 
 namespace Exolnet\Image\Tests\Unit;
 
+use Exolnet\Image\Image;
 use Exolnet\Image\ImageService;
 use Exolnet\Image\Repository\FilesystemRepository;
 use Exolnet\Image\Tests\UnitTest;
 use Mockery as m;
+use Symfony\Component\HttpFoundation\File\File;
 
 class ImageServiceTest extends UnitTest
 {
-    /**
-     * @var \Exolnet\Image\ImageService
-     */
+    /** @var \Exolnet\Image\ImageService */
     protected $service;
 
-    /**
-     * @var \Mockery\MockInterface
-     */
+    /** @var \Mockery\MockInterface */
     protected $filesystemRepository;
+
+    /** @var \Mockery\Mock|\Exolnet\Image\ImageService */
+    private $mockedService;
+
+    /** @var \Mockery\Mock|\Symfony\Component\HttpFoundation\File\File */
+    private $file;
+
+    /** @var \Mockery\Mock|\Exolnet\Image\Image */
+    private $image;
 
     public function setUp(): void
     {
         $this->filesystemRepository = m::mock(FilesystemRepository::class);
 
         $this->service = new ImageService($this->filesystemRepository);
+
+        $this->mockedService = m::mock(ImageService::class)->makePartial();
+
+        $this->file = m::mock(File::class)->makePartial();
+        $this->image = m::mock(Image::class)->makePartial();
     }
 
+    /**
+     * @test
+     * @return void
+     */
     public function testItIsInitializable()
     {
         $this->assertInstanceOf(ImageService::class, $this->service);
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testCreateImage()
+    {
+        $this->image->shouldReceive('save')->twice();
+
+        $this->file->shouldReceive('getBaseName')->once()->andReturn('test');
+        $this->file->shouldReceive('guessExtension')->once()->andReturn('png');
+
+        $this->mockedService->shouldAllowMockingProtectedMethods()
+            ->shouldReceive('makeImage')->once()->andReturn($this->image);
+        $this->mockedService->shouldReceive('store')->once()
+            ->with($this->image, $this->file)->andReturn(true);
+
+        $this->assertEquals($this->image, $this->mockedService->createImage($this->file));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testDestroy()
+    {
+        $this->image = m::mock(Image::class)->makePartial();
+        $this->mockedDestroy(true);
+        $this->assertTrue($this->service->destroy($this->image));
+    }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function testReplace()
+    {
+        $this->mockedDestroy(true);
+        $this->mockedStore();
+        $this->assertTrue($this->service->replace($this->image, $this->file));
+
+        $this->mockedDestroy(false);
+        $this->assertFalse($this->service->replace($this->image, $this->file));
+    }
+
+    /**
+     * @param bool $valueExpected
+     */
+    public function mockedDestroy(bool $valueExpected)
+    {
+        $this->filesystemRepository->shouldReceive('destroy')->once()->with($this->image)->andReturn($valueExpected);
+    }
+
+    public function mockedStore()
+    {
+        $this->filesystemRepository->shouldReceive('store')->once()
+            ->with($this->image, $this->file)->andReturn(true);
     }
 }

--- a/tests/Unit/ImageServiceTest.php
+++ b/tests/Unit/ImageServiceTest.php
@@ -167,12 +167,13 @@ class ImageServiceTest extends UnitTest
     /**
      * @test
      * @return void
+     * @throws \Exception
      */
     public function testDeleteImage()
     {
         $this->filesystemRepository->shouldReceive('destroy')->with($this->image)->andReturn(true);
         $this->image->shouldReceive('delete')->andReturn(true);
-        $this->assertFalse($this->service->deleteImage($this->image));
+        $this->assertTrue($this->service->deleteImage($this->image));
     }
 
     /**

--- a/tests/Unit/ImageTest.php
+++ b/tests/Unit/ImageTest.php
@@ -21,4 +21,10 @@ class ImageTest extends UnitTest
     {
         $this->assertInstanceOf(Image::class, $this->model);
     }
+
+    public function testGetSetFileName()
+    {
+        $this->model->setFilename('test.png');
+        $this->assertEquals('test.png', $this->model->getFilename());
+    }
 }


### PR DESCRIPTION
- Improved test coverage from 33% files, 4% lines to 100% files, 83% lines.
The 17% left are getters in the Image model and a protected method ImageService::makeImage()

- Changed the logic for ImageService::deleteImage to return Image::delete instead of false.

- Took out the creation of an image in ImageService::createImage and added protected method ImageService::makeImage for better testing